### PR TITLE
Add missing breadcrumbs prop to PolarisPage.

### DIFF
--- a/src/components/PolarisPage.vue
+++ b/src/components/PolarisPage.vue
@@ -3,6 +3,7 @@
     <polaris-page-header
         :title="title"
         :icon="icon"
+        :breadcrumbs="breadcrumbs"
         :separator="separator"
         :primary-action="primaryAction"
         :secondary-actions="secondaryActions"


### PR DESCRIPTION
I noticed that breadcrumbs weren't working locally or on the [demo page](http://demo.polaris-vue.eastsideco.io) for PolarisPage.