### PR TITLE
Hide logging for polaris components in production

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,7 @@ export default {
             var componentName = ComponentHelpers.getComponentName(polarisName);
             Vue.component(componentName, components[polarisName]);
             count++;
-            console.log(componentName + ' -> ' + polarisName);
+            log.send(log.DEBUG, TAG, 'componentName + ' -> ' + polarisName');
         }
 
         log.send(log.DEBUG, TAG, 'Installed '+count+' components.');


### PR DESCRIPTION
Hi! Noticed this line was producing console.logs in my production environment. 